### PR TITLE
Use platform-specific C-char type in public API

### DIFF
--- a/cmaybenot/src/ffi.rs
+++ b/cmaybenot/src/ffi.rs
@@ -1,6 +1,10 @@
 use crate::error::MaybenotResult;
 use crate::{Maybenot, MaybenotAction, MaybenotEvent};
-use std::{ffi::CStr, mem::MaybeUninit, slice::from_raw_parts_mut};
+use core::{
+    ffi::{c_char, CStr},
+    mem::MaybeUninit,
+    slice::from_raw_parts_mut,
+};
 
 /// Start a new [Maybenot] instance.
 ///
@@ -9,7 +13,7 @@ use std::{ffi::CStr, mem::MaybeUninit, slice::from_raw_parts_mut};
 /// - `out` must be a valid pointer to some valid pointer-sized memory.
 #[no_mangle]
 pub unsafe extern "C" fn maybenot_start(
-    machines_str: *const i8,
+    machines_str: *const c_char,
     max_padding_bytes: f64,
     max_blocking_bytes: f64,
     mtu: u16,


### PR DESCRIPTION
Currently, `cmaybenot` fails to compile on ARM due to the wrong type of C char being used in one place. This PR addresses that by using a platform-dependent, FFI-friendly c_char type!

As per Joakim's wish, I've changed some imports from `std` to `core` as well :rocket:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-go/2)
<!-- Reviewable:end -->
