### PR TITLE
Constant packet size

### DIFF
--- a/device/daita.go
+++ b/device/daita.go
@@ -282,7 +282,7 @@ func cActionToGo(action_c C.MaybenotAction) Action {
 	return Action{
 		Machine:    uint64(padding_action.machine),
 		Timeout:    timeout,
-		ActionType: 1, // TODO
+		ActionType: ActionTypeInjectPadding,
 		Payload: Padding{
 			ByteCount: uint16(padding_action.size),
 			Replace:   bool(padding_action.replace),

--- a/device/daita.go
+++ b/device/daita.go
@@ -84,11 +84,8 @@ func (peer *Peer) EnableDaita(machines string, eventsCapacity uint, actionsCapac
 	peer.device.log.Verbosef("Enabling DAITA for peer: %v", peer)
 	peer.device.log.Verbosef("Params: eventsCapacity=%v, actionsCapacity=%v", eventsCapacity, actionsCapacity) // TODO: Deleteme
 
-	mtu, err := peer.device.tun.device.MTU()
-	if err != nil {
-		peer.device.log.Errorf("Failed to activate DAITA as because of error fetching MTU, %v", err)
-		return false
-	}
+	mtu := peer.device.tun.mtu.Load()
+
 	peer.device.log.Verbosef("MTU %v", mtu)
 	var maybenot *C.MaybenotFramework
 	c_machines := C.CString(machines)

--- a/device/daita.go
+++ b/device/daita.go
@@ -261,6 +261,7 @@ func (daita *MaybenotDaita) maybenotEventToActions(event Event) []C.MaybenotActi
 	result := C.maybenot_on_events(daita.maybenot, &cEvent, 1, &daita.newActionsBuf[0], &actionsWritten)
 	if result != 0 {
 		daita.logger.Errorf("Failed to handle event as it was a null pointer\nEvent: %d\n", event)
+		return nil
 	}
 
 	newActions := daita.newActionsBuf[:actionsWritten]

--- a/device/daita.go
+++ b/device/daita.go
@@ -181,16 +181,15 @@ func injectPadding(action Action, peer *Peer) {
 	elem.padding = true
 	elem.machine_id = &action.Machine
 
-	size := action.Payload.ByteCount + DaitaHeaderLen
-	if size == 0 {
+	size := action.Payload.ByteCount
+	if size < DaitaHeaderLen || size > uint16(peer.device.tun.mtu.Load()) {
 		peer.device.log.Errorf("DAITA padding action contained invalid size %v bytes", size)
 		return
 	}
 
 	elem.packet = elem.buffer[MessageTransportHeaderSize : MessageTransportHeaderSize+int(size)]
 	elem.packet[0] = DaitaPaddingMarker
-	daitaLengthField := binary.BigEndian.AppendUint16([]byte{}, size)
-	copy(elem.packet[DaitaOffsetTotalLength:DaitaOffsetTotalLength+2], daitaLengthField)
+	binary.BigEndian.PutUint16(elem.packet[DaitaOffsetTotalLength:DaitaOffsetTotalLength+2], size)
 
 	peer.StagePacket(elem)
 }

--- a/device/peer.go
+++ b/device/peer.go
@@ -54,7 +54,8 @@ type Peer struct {
 	trieEntries                 list.List
 	persistentKeepaliveInterval atomic.Uint32
 
-	daita Daita
+	daita              Daita
+	constantPacketSize bool
 }
 
 func (device *Device) NewPeer(pk NoisePublicKey) (*Peer, error) {

--- a/device/send.go
+++ b/device/send.go
@@ -50,7 +50,8 @@ type QueueOutboundElement struct {
 	nonce      uint64                // nonce for encryption
 	keypair    *Keypair              // keypair for encryption
 	peer       *Peer                 // related peer
-	padding    bool                  // elem is a DAITA padding packet
+	keepalive  bool                  // is a keepalive message
+	padding    bool                  // is a DAITA padding packet
 	machine_id *uint64               // machine ID that ordered said padding packet
 }
 
@@ -79,6 +80,7 @@ func (elem *QueueOutboundElement) clearPointers() {
 func (peer *Peer) SendKeepalive() {
 	if len(peer.queue.staged) == 0 && peer.isRunning.Load() {
 		elem := peer.device.NewOutboundElement()
+		elem.keepalive = true
 		select {
 		case peer.queue.staged <- elem:
 			peer.device.log.Verbosef("%v - Sending keepalive packet", peer)
@@ -306,6 +308,8 @@ top:
 		return
 	}
 
+	allZeros := [MaxMessageSize]byte{}
+
 	for {
 		select {
 		case elem := <-peer.queue.staged:
@@ -315,6 +319,26 @@ top:
 				keypair.sendNonce.Store(RejectAfterMessages)
 				peer.StagePacket(elem) // XXX: Out of order, but we can't front-load go chans
 				goto top
+			}
+
+			if peer.constantPacketSize {
+				mtu := int(peer.device.tun.mtu.Load())
+				size := len(elem.packet)
+				offset := MessageTransportHeaderSize
+				// size should not and cannot be larger than mtu as far as we can tell, but for safety we check
+				if mtu > size {
+					// Here, we extend the packet to always be MTU sized as an obfuscation.
+					if offset+mtu < len(elem.buffer) {
+						elem.packet = elem.buffer[offset : offset+mtu]
+					} else {
+						elem.packet = elem.buffer[offset:]
+					}
+
+					// To avoid sending data from the previous packet, we need to clear the extra buffer content that we add.
+					// TODO: When go is updated to 1.21, use this instead to clear the slice:
+					// clear(elem.packet[size:])
+					copy(elem.packet[size:], allZeros[:])
+				}
 			}
 
 			elem.keypair = keypair
@@ -438,19 +462,19 @@ func (peer *Peer) RoutineSequentialSender() {
 		// send message and return buffer to pool
 
 		err := peer.SendBuffer(elem.packet)
-		if len(elem.packet) != MessageKeepaliveSize {
+		if !elem.keepalive {
 			peer.timersDataSent()
-		}
 
-		if peer.daita != nil {
-			if elem.padding {
-				if elem.machine_id == nil {
-					device.log.Errorf("Machine ID missing for PaddingSent event")
+			if peer.daita != nil {
+				if elem.padding {
+					if elem.machine_id == nil {
+						device.log.Errorf("Machine ID missing for PaddingSent event")
+					} else {
+						peer.daita.PaddingSent(peer, uint(len(elem.packet)), *elem.machine_id)
+					}
 				} else {
-					peer.daita.PaddingSent(peer, uint(len(elem.packet)), *elem.machine_id)
+					peer.daita.NonpaddingSent(peer, uint(len(elem.packet)))
 				}
-			} else {
-				peer.daita.NonpaddingSent(peer, uint(len(elem.packet)))
 			}
 		}
 

--- a/device/send.go
+++ b/device/send.go
@@ -464,18 +464,6 @@ func (peer *Peer) RoutineSequentialSender() {
 		err := peer.SendBuffer(elem.packet)
 		if !elem.keepalive {
 			peer.timersDataSent()
-
-			if peer.daita != nil {
-				if elem.padding {
-					if elem.machine_id == nil {
-						device.log.Errorf("Machine ID missing for PaddingSent event")
-					} else {
-						peer.daita.PaddingSent(peer, uint(len(elem.packet)), *elem.machine_id)
-					}
-				} else {
-					peer.daita.NonpaddingSent(peer, uint(len(elem.packet)))
-				}
-			}
 		}
 
 		device.PutMessageBuffer(elem.buffer)
@@ -483,6 +471,18 @@ func (peer *Peer) RoutineSequentialSender() {
 		if err != nil {
 			device.log.Errorf("%v - Failed to send data packet: %v", peer, err)
 			continue
+		}
+
+		if peer.daita != nil && !elem.keepalive {
+			if elem.padding {
+				if elem.machine_id == nil {
+					device.log.Errorf("Machine ID missing for PaddingSent event")
+				} else {
+					peer.daita.PaddingSent(peer, uint(len(elem.packet)), *elem.machine_id)
+				}
+			} else {
+				peer.daita.NonpaddingSent(peer, uint(len(elem.packet)))
+			}
 		}
 
 		peer.keepKeyFreshSending()

--- a/device/uapi.go
+++ b/device/uapi.go
@@ -387,6 +387,16 @@ func (device *Device) handlePeerLine(peer *ipcSetPeer, key, value string) error 
 		if value != "1" {
 			return ipcErrorf(ipc.IpcErrorInvalid, "invalid protocol version: %v", value)
 		}
+	case "constant_packet_size":
+		if value != "true" {
+			return ipcErrorf(ipc.IpcErrorInvalid, "failed to set constant packet size, invalid value: %v", value)
+		}
+		if peer.dummy {
+			return nil
+		}
+		peer.Lock()
+		defer peer.Unlock()
+		peer.constantPacketSize = true
 
 	default:
 		return ipcErrorf(ipc.IpcErrorInvalid, "invalid UAPI peer key: %v", key)


### PR DESCRIPTION
This PR implements constant packet size in `wireguard-go`. To test it with the daemon, checkout the `constant-packet-size` branch of the app repo (and `submodule update --recursive`), which enables the feature when connected to a DAITA server.

* [x] Constant packet size is hard coded to be enabled. Switch to exposing an apporopriate setting through FFI so it can be enabled by the daemon. This is a bit tricky to get right, as we need it to be compatible with how constant packet size is enabled in wireguard NT.
* [x] Investigate performance hit from clearing the send buffer and optimize if needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-go/4)
<!-- Reviewable:end -->
