### PR TITLE
Fix padding stage bug

### DIFF
--- a/device/daita.go
+++ b/device/daita.go
@@ -178,9 +178,6 @@ func injectPadding(action Action, peer *Peer) {
 
 	elem := peer.device.NewOutboundElement()
 
-	elem.padding = true
-	elem.machine_id = &action.Machine
-
 	size := action.Payload.ByteCount
 	if size < DaitaHeaderLen || size > uint16(peer.device.tun.mtu.Load()) {
 		peer.device.log.Errorf("DAITA padding action contained invalid size %v bytes", size)
@@ -195,8 +192,9 @@ func injectPadding(action Action, peer *Peer) {
 		peer.StagePacket(elem)
 		elem = nil
 		peer.SendStagedPackets()
-	}
 
+		peer.daita.PaddingSent(peer, uint(size), action.Machine)
+	}
 }
 
 func (daita *MaybenotDaita) handleEvents(peer *Peer) {

--- a/device/daita.go
+++ b/device/daita.go
@@ -191,7 +191,12 @@ func injectPadding(action Action, peer *Peer) {
 	elem.packet[0] = DaitaPaddingMarker
 	binary.BigEndian.PutUint16(elem.packet[DaitaOffsetTotalLength:DaitaOffsetTotalLength+2], size)
 
-	peer.StagePacket(elem)
+	if peer.isRunning.Load() {
+		peer.StagePacket(elem)
+		elem = nil
+		peer.SendStagedPackets()
+	}
+
 }
 
 func (daita *MaybenotDaita) handleEvents(peer *Peer) {


### PR DESCRIPTION
This PR contains two changes:

The first is a fix to actually send the inject padding packets, not just stage them. This likely caused them to not be sent until a non-padding packet was sent. A small oversight with huge security implications.

The second change is a to produce `NonpaddingSent` and `PaddingSent`  events before encryption of the outgoing packet. This behavior is more in line with the reference implementation. It also makes it easier to identify padding, non-padding and keep-alive elements and removes the need for marker fields on the outgoing element.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-go/5)
<!-- Reviewable:end -->
