### PR TITLE
Fix linker arguments for maybenot on macOS

### DIFF
--- a/device/daita.go
+++ b/device/daita.go
@@ -13,7 +13,7 @@ import (
 // #include <stdio.h>
 // #include <stdlib.h>
 // #include "../maybenot/crates/maybenot-ffi/maybenot.h"
-// #cgo LDFLAGS: -L${SRCDIR}/../ -l:libmaybenot.a -lm
+// #cgo LDFLAGS: -L${SRCDIR}/../ -lmaybenot -lm
 import "C"
 
 type MaybenotDaita struct {


### PR DESCRIPTION
The `-l:libmaybenot.a` syntax does not work here, it seems. This PR simply replaces it with `-lmaybenot`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-go/8)
<!-- Reviewable:end -->
