### PR TITLE
Fix leak in netstack's tunnel device

### DIFF
--- a/tun/netstack/tun.go
+++ b/tun/netstack/tun.go
@@ -157,6 +157,7 @@ func (tun *netTun) Flush() error {
 
 func (tun *netTun) Close() error {
 	tun.stack.RemoveNIC(1)
+	tun.stack.Close()
 
 	if tun.events != nil {
 		close(tun.events)


### PR DESCRIPTION
The upstream netstack's virtual tunnel device has a leaky Close implementation - the virtual network is not being shut down properly. What's missing is this one line change to shut down all the go routines associated with the userspace networking stack. This change is verbatim copied from kshangx's PR - https://github.com/WireGuard/wireguard-go/pull/101

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-go/10)
<!-- Reviewable:end -->
