### PR TITLE
Fix events being sent after the `events` channel has been closed, and add changelog

### DIFF
--- a/MULLVAD-CHANGELOG.md
+++ b/MULLVAD-CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+All notable changes are recorded here.
+
+### Format
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+Entries should have the imperative form, just like commit messages. Start each entry with words like
+add, fix, increase, force etc.. Not added, fixed, increased, forced etc.
+
+Line wrap the file at 100 chars.                                              That is over here -> |
+
+### Categories each change fall into
+
+* **Added**: for new features.
+* **Changed**: for changes in existing functionality.
+* **Deprecated**: for soon-to-be removed features.
+* **Removed**: for now removed features.
+* **Fixed**: for any bug fixes.
+* **Security**: in case of vulnerabilities.
+
+## [Unreleased]
+### Fixed
+- Fix netstack tunnel leaking when closed.
+- Fix race when closing the DAITA event channel, which could result in events being sent on the
+  closed channel.
+
+
+## [0.1.0] - 2024-07-25
+### Added
+- Initial DAITA release.

--- a/device/peer.go
+++ b/device/peer.go
@@ -257,8 +257,9 @@ func (peer *Peer) Stop() {
 	peer.queue.outbound.c <- nil
 
 	if peer.daita != nil {
-		peer.daita.Close()
+		daita := peer.daita
 		peer.daita = nil
+		daita.Close()
 	}
 
 	peer.stopping.Wait()


### PR DESCRIPTION
Events can be sent after the channel has been closed:

```
panic: send on closed channel

goroutine 1665 [running]:
golang.zx2c4.com/wireguard/device.(*MaybenotDaita).event(0x14000372230, 0x140005ec000, 0x3a6f18?, 0x105f622a0?, 0x107b70480?)
	/Users/user/mullvadvpn-app/wireguard-go-rs/libwg/wireguard-go/device/daita.go:166 +0x128
golang.zx2c4.com/wireguard/device.(*MaybenotDaita).PaddingReceived(0x140005ec000?, 0x107a9e4b0?, 0x14000204200?)
	/Users/user/mullvadvpn-app/wireguard-go-rs/libwg/wireguard-go/device/daita.go:140 +0x28
golang.zx2c4.com/wireguard/device.(*Peer).RoutineSequentialReceiver(0x140005ec000)
	/Users/user/mullvadvpn-app/wireguard-go-rs/libwg/wireguard-go/device/receive.go:451 +0x324
created by golang.zx2c4.com/wireguard/device.(*Peer).Start in goroutine 1637
	/Users/user/mullvadvpn-app/wireguard-go-rs/libwg/wireguard-go/device/peer.go:194 +0x29c
zsh: abort      sudo MULLVAD_RESOURCE_DIR=./dist-assets ./target/debug/mullvad-daemon -vvv
```

Reproducing the above with `mullvad-daemon`:
1. Enable DAITA.
2. Set a breakpoint on `on_set_relay_settings`.
3. Switch location, hit the breakpoint, and wait for a while.
4. Continue.

Fix DES-1154.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-go/12)
<!-- Reviewable:end -->
