### PR TITLE
Fix keepalive flag not being reset when retrieving new packets from pool

### DIFF
--- a/MULLVAD-CHANGELOG.md
+++ b/MULLVAD-CHANGELOG.md
@@ -20,6 +20,10 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+### Fixed
+- Fix keepalive flag not being reset for pooled packets. This could result in fewer client
+  handshakes over time.
+
 
 ## [0.1.3] - 2024-10-29
 ### Changed

--- a/device/send.go
+++ b/device/send.go
@@ -58,6 +58,7 @@ func (device *Device) NewOutboundElement() *QueueOutboundElement {
 	elem.buffer = device.GetMessageBuffer()
 	elem.Mutex = sync.Mutex{}
 	elem.nonce = 0
+	elem.keepalive = false
 	// keypair and peer were cleared (if necessary) by clearPointers.
 	return elem
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-go/17)
<!-- Reviewable:end -->
