### PR TITLE
Add DAITA V2 support

### DIFF
--- a/MULLVAD-CHANGELOG.md
+++ b/MULLVAD-CHANGELOG.md
@@ -20,7 +20,15 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+### Added
+- Add support for DAITA machine timers, and tunnel recv and send events.
+
+### Changed
+- Optimize handling of DAITA events by sending all available events in the channel to the Maybenot
+  framework.
+
 ### Fixed
+- Handle replace flag for padding packets.
 - Fix keepalive flag not being reset for pooled packets. This could result in fewer client
   handshakes over time.
 

--- a/device/daita.go
+++ b/device/daita.go
@@ -20,19 +20,19 @@ type MaybenotDaita struct {
 	events          chan Event
 	eventsClosed    bool
 	eventsCloseLock sync.RWMutex
+	eventsCBuf      []C.MaybenotEvent
 	actions         chan Action
 	maybenot        *C.MaybenotFramework
 	newActionsBuf   []C.MaybenotAction
 	paddingQueue    map[uint64]*time.Timer   // Map from machine to queued padding packets
 	machineTimers   map[uint64]*MachineTimer // Map from machine to machine timer
 	logger          *Logger
-	stopping        sync.WaitGroup // waitgroup for handleEvents and HandleDaitaActions
+	stopping        sync.WaitGroup // waitgroup for runEventLoop and HandleDaitaActions
 }
 
 type MachineTimer struct {
-	started time.Time
-	timeout time.Duration
-	timer   *time.Timer
+	completeAt time.Time
+	timer      *time.Timer
 }
 
 func (timer *MachineTimer) Stop() bool {
@@ -41,9 +41,8 @@ func (timer *MachineTimer) Stop() bool {
 
 func newMachineTimer(timeout time.Duration, callback func()) *MachineTimer {
 	return &MachineTimer{
-		started: time.Now(),
-		timeout: timeout,
-		timer:   time.AfterFunc(timeout, callback),
+		completeAt: time.Now().Add(timeout),
+		timer:      time.AfterFunc(timeout, callback),
 	}
 }
 
@@ -60,7 +59,7 @@ const (
 	ERROR_INTERMITTENT_FAILURE = -2
 )
 
-// TODO: Consider using an Action interface, and defining MaybenotDaita.handleEvent as a method on
+// TODO: Consider using an Action interface, and defining MaybenotDaita.handleEvents as a method on
 // that interface. Each Action enum variant could be an implenentation on that interface, that way
 // we wouldn't have to flatten the Action enum into this ugly struct.
 // Performance may be a concern though.
@@ -128,6 +127,7 @@ func (peer *Peer) EnableDaita(machines string, eventsCapacity uint, actionsCapac
 	numMachines := C.maybenot_num_machines(maybenot)
 	daita := MaybenotDaita{
 		events:        make(chan Event, eventsCapacity),
+		eventsCBuf:    make([]C.MaybenotEvent, eventsCapacity),
 		eventsClosed:  false,
 		maybenot:      maybenot,
 		newActionsBuf: make([]C.MaybenotAction, numMachines),
@@ -137,7 +137,7 @@ func (peer *Peer) EnableDaita(machines string, eventsCapacity uint, actionsCapac
 	}
 
 	daita.stopping.Add(1)
-	go daita.handleEvents(peer)
+	go daita.runEventLoop(peer)
 
 	peer.daita = &daita
 
@@ -256,24 +256,50 @@ func injectPadding(action Action, peer *Peer) {
 	}
 }
 
-func (daita *MaybenotDaita) handleEvents(peer *Peer) {
+func (daita *MaybenotDaita) runEventLoop(peer *Peer) {
 	defer func() {
 		C.maybenot_stop(daita.maybenot)
 		daita.stopping.Done()
 		daita.logger.Verbosef("%v - DAITA: event handler - stopped", peer)
 	}()
 
+	events := make([]Event, len(daita.events))
+
 	for {
+		events = events[:0]
+
 		event, more := <-daita.events
 		if !more {
 			return
 		}
 
-		daita.handleEvent(event, peer)
+		events = append(events, event)
+
+		// Drain remaining events
+	HandleEvents:
+		for {
+			select {
+			case event, more := <-daita.events:
+				if !more {
+					daita.logger.Verbosef("%v - DAITA: dropping %d unhandled events", peer, len(events))
+					return
+				}
+				events = append(events, event)
+
+				// Make sure not to exceed the maximum C buffer capacity
+				if len(events) >= len(daita.eventsCBuf) {
+					break HandleEvents
+				}
+			default:
+				break HandleEvents
+			}
+		}
+
+		daita.handleEvents(events, peer)
 	}
 }
 
-func (daita *MaybenotDaita) handleEvent(event Event, peer *Peer) {
+func (daita *MaybenotDaita) handleEvents(event []Event, peer *Peer) {
 	for _, cAction := range daita.maybenotEventToActions(event) {
 		action := cActionToGo(cAction)
 
@@ -313,35 +339,22 @@ func (daita *MaybenotDaita) handleEvent(event Event, peer *Peer) {
 			// Check if a padding packet was already queued for the machine
 			timer, timerWasQueued := daita.machineTimers[action.Machine]
 
-			startNewTimer := false
-
-			if !timerWasQueued {
-				// Start timer if it does not exist
+			var startNewTimer bool
+			if !timerWasQueued || action.Replace {
+				// Always start timer if it does not exist or if the replace flag is set
 				startNewTimer = true
 			} else {
-				shouldReplace := false
-				if action.Replace {
-					shouldReplace = true
-				} else {
-					elapsed := time.Since(timer.started)
-					if elapsed >= timer.timeout {
-						// Timer has (or should have) already fired
-						shouldReplace = true
-					} else {
-						timeLeft := timer.timeout - elapsed
-
-						// Replace timer if action duration is greater than the time left
-						shouldReplace = action.Duration > timeLeft
-					}
-				}
-
-				startNewTimer = shouldReplace
+				now := time.Now()
+				// Replace timer if it (should have) already fired (completeAt - now is negative)
+				// or in general if the action duration is greater than the time left
+				startNewTimer = action.Duration > timer.completeAt.Sub(now)
 			}
 
 			// Replace or start new timer
 			if startNewTimer {
 				if !timerWasQueued || !timer.Stop() {
-					// If the previous timer fired or didn't run, increment stopping wait group
+					// If no timer was cancelled, increment wait group
+					// This is because the timer will decrement the wait group when it fires
 					daita.stopping.Add(1)
 				}
 
@@ -374,19 +387,20 @@ func (daita *MaybenotDaita) stopPaddingTimer(machine uint64) {
 	}
 }
 
-func (daita *MaybenotDaita) maybenotEventToActions(event Event) []C.MaybenotAction {
-	cEvent := C.MaybenotEvent{
-		machine:    C.uintptr_t(event.Machine),
-		event_type: C.uint32_t(event.EventType),
+func (daita *MaybenotDaita) maybenotEventToActions(events []Event) []C.MaybenotAction {
+	for i := 0; i < len(events); i++ {
+		daita.eventsCBuf[i] = C.MaybenotEvent{
+			machine:    C.uintptr_t(events[i].Machine),
+			event_type: C.uint32_t(events[i].EventType),
+		}
 	}
 
 	var actionsWritten C.uintptr_t
 
-	// TODO: use unsafe.SliceData instead of the pointer dereference when the Go version gets bumped to 1.20 or later
-	// TODO: fetch an error string from the FFI corresponding to the error code
-	result := C.maybenot_on_events(daita.maybenot, &cEvent, 1, &daita.newActionsBuf[0], &actionsWritten)
+	firstElem := (*C.MaybenotEvent)(unsafe.SliceData(daita.eventsCBuf))
+	result := C.maybenot_on_events(daita.maybenot, firstElem, C.ulong(len(events)), &daita.newActionsBuf[0], &actionsWritten)
 	if result != 0 {
-		daita.logger.Errorf("Failed to handle event as it was a null pointer\nEvent: %d\n", event)
+		daita.logger.Errorf("Failed to handle event as it was a null pointer")
 		return nil
 	}
 

--- a/device/daita.go
+++ b/device/daita.go
@@ -231,7 +231,15 @@ func injectPadding(action Action, peer *Peer) {
 		return
 	}
 
+	if action.Replace && peer.HasReplaceablePackets() {
+		peer.ReplacedPacketsInc()
+		peer.daita.PaddingSent(peer, action.Machine)
+		return
+	}
+
 	elem := peer.device.NewOutboundElement()
+	elem.daitaPadding = true
+
 	// All packets are MTU-sized when DAITA is enabled
 	size := uint16(peer.device.tun.mtu.Load())
 

--- a/device/daita.go
+++ b/device/daita.go
@@ -23,9 +23,28 @@ type MaybenotDaita struct {
 	actions         chan Action
 	maybenot        *C.MaybenotFramework
 	newActionsBuf   []C.MaybenotAction
-	paddingQueue    map[uint64]*time.Timer // Map from machine to queued padding packets
+	paddingQueue    map[uint64]*time.Timer   // Map from machine to queued padding packets
+	machineTimers   map[uint64]*MachineTimer // Map from machine to machine timer
 	logger          *Logger
 	stopping        sync.WaitGroup // waitgroup for handleEvents and HandleDaitaActions
+}
+
+type MachineTimer struct {
+	started time.Time
+	timeout time.Duration
+	timer   *time.Timer
+}
+
+func (timer *MachineTimer) Stop() bool {
+	return timer.timer.Stop()
+}
+
+func newMachineTimer(timeout time.Duration, callback func()) *MachineTimer {
+	return &MachineTimer{
+		started: time.Now(),
+		timeout: timeout,
+		timer:   time.AfterFunc(timeout, callback),
+	}
 }
 
 type Event struct {
@@ -58,7 +77,7 @@ type Action struct {
 	Timer C.MaybenotTimer
 
 	// The time at which the action should be performed
-	// Used for ActionTypes: SendPadding, BlockOutgoing, UpdateTimer
+	// Used for ActionTypes: SendPadding, BlockOutgoing
 	Timeout time.Duration
 
 	// Used for ActionTypes: BlockOutgoing, UpdateTimer
@@ -113,6 +132,7 @@ func (peer *Peer) EnableDaita(machines string, eventsCapacity uint, actionsCapac
 		maybenot:      maybenot,
 		newActionsBuf: make([]C.MaybenotAction, numMachines),
 		paddingQueue:  map[uint64]*time.Timer{},
+		machineTimers: map[uint64]*MachineTimer{},
 		logger:        peer.device.log,
 	}
 
@@ -132,6 +152,12 @@ func (daita *MaybenotDaita) Close() {
 	close(daita.events)
 	daita.eventsClosed = true
 	daita.eventsCloseLock.Unlock()
+
+	for _, timer := range daita.machineTimers {
+		if timer.Stop() {
+			daita.stopping.Done()
+		}
+	}
 
 	for _, queuedPadding := range daita.paddingQueue {
 		if queuedPadding.Stop() {
@@ -156,6 +182,14 @@ func (daita *MaybenotDaita) PaddingSent(peer *Peer, machine uint64) {
 
 func (daita *MaybenotDaita) NormalSent(peer *Peer) {
 	daita.event(peer, NormalSent, 0)
+}
+
+func (daita *MaybenotDaita) timerBegin(peer *Peer, machine uint64) {
+	daita.event(peer, TimerBegin, machine)
+}
+
+func (daita *MaybenotDaita) timerEnd(peer *Peer, machine uint64) {
+	daita.event(peer, TimerEnd, machine)
 }
 
 func (daita *MaybenotDaita) event(peer *Peer, eventType EventType, machine uint64) {
@@ -230,12 +264,17 @@ func (daita *MaybenotDaita) handleEvent(event Event, peer *Peer) {
 		switch action.ActionType {
 		case C.MaybenotAction_Cancel:
 			machine := action.Machine
-			// If padding is queued for the machine, cancel it
-			if queuedPadding, ok := daita.paddingQueue[machine]; ok {
-				if queuedPadding.Stop() {
-					daita.stopping.Done()
-				}
+
+			switch action.Timer {
+			case C.MaybenotTimer_Action:
+				daita.stopPaddingTimer(machine)
+			case C.MaybenotTimer_Internal:
+				daita.stopMachineTimer(machine)
+			case C.MaybenotTimer_All:
+				daita.stopMachineTimer(machine)
+				daita.stopPaddingTimer(machine)
 			}
+
 		case C.MaybenotAction_SendPadding:
 			// Check if a padding packet was already queued for the machine
 			// If so, try to cancel it
@@ -254,11 +293,67 @@ func (daita *MaybenotDaita) handleEvent(event Event, peer *Peer) {
 		case C.MaybenotAction_BlockOutgoing:
 			// TODO: implement BlockOutgoing
 			daita.logger.Errorf("ignoring BlockOutgoing action, unimplemented")
-			continue
 		case C.MaybenotAction_UpdateTimer:
-			// TODO: implement UpdateTimer
-			daita.logger.Errorf("ignoring UpdateTimer action, unimplemented")
-			continue
+			// Check if a padding packet was already queued for the machine
+			timer, timerWasQueued := daita.machineTimers[action.Machine]
+
+			startNewTimer := false
+
+			if !timerWasQueued {
+				// Start timer if it does not exist
+				startNewTimer = true
+			} else {
+				shouldReplace := false
+				if action.Replace {
+					shouldReplace = true
+				} else {
+					elapsed := time.Since(timer.started)
+					if elapsed >= timer.timeout {
+						// Timer has (or should have) already fired
+						shouldReplace = true
+					} else {
+						timeLeft := timer.timeout - elapsed
+
+						// Replace timer if action duration is greater than the time left
+						shouldReplace = action.Duration > timeLeft
+					}
+				}
+
+				startNewTimer = shouldReplace
+			}
+
+			// Replace or start new timer
+			if startNewTimer {
+				if !timerWasQueued || !timer.Stop() {
+					// If the previous timer fired or didn't run, increment stopping wait group
+					daita.stopping.Add(1)
+				}
+
+				daita.timerBegin(peer, action.Machine)
+				daita.machineTimers[action.Machine] =
+					newMachineTimer(action.Duration, func() {
+						// Decrement wait group counter
+						defer daita.stopping.Done()
+
+						daita.timerEnd(peer, action.Machine)
+					})
+			}
+		}
+	}
+}
+
+func (daita *MaybenotDaita) stopMachineTimer(machine uint64) {
+	if timer, ok := daita.machineTimers[machine]; ok {
+		if timer.Stop() {
+			daita.stopping.Done()
+		}
+	}
+}
+
+func (daita *MaybenotDaita) stopPaddingTimer(machine uint64) {
+	if queuedPadding, ok := daita.paddingQueue[machine]; ok {
+		if queuedPadding.Stop() {
+			daita.stopping.Done()
 		}
 	}
 }

--- a/device/daita.go
+++ b/device/daita.go
@@ -90,7 +90,7 @@ type Action struct {
 	Bypass bool
 }
 
-func (peer *Peer) EnableDaita(machines string, eventsCapacity uint, actionsCapacity uint, maxPaddingBytes float64, maxBlockingBytes float64) bool {
+func (peer *Peer) EnableDaita(machines string, eventsCapacity uint, actionsCapacity uint, maxPaddingFrac float64, maxBlockingFrac float64) bool {
 	peer.Lock()
 	defer peer.Unlock()
 
@@ -111,11 +111,11 @@ func (peer *Peer) EnableDaita(machines string, eventsCapacity uint, actionsCapac
 	var maybenot *C.MaybenotFramework
 	c_machines := C.CString(machines)
 
-	c_maxPaddingBytes := C.double(maxPaddingBytes)
-	c_maxBlockingBytes := C.double(maxBlockingBytes)
+	c_maxPaddingFrac := C.double(maxPaddingFrac)
+	c_maxBlockingFrac := C.double(maxBlockingFrac)
 
 	maybenot_result := C.maybenot_start(
-		c_machines, c_maxPaddingBytes, c_maxBlockingBytes,
+		c_machines, c_maxPaddingFrac, c_maxBlockingFrac,
 		&maybenot,
 	)
 	C.free(unsafe.Pointer(c_machines))

--- a/device/daita.go
+++ b/device/daita.go
@@ -184,6 +184,14 @@ func (daita *MaybenotDaita) NormalSent(peer *Peer) {
 	daita.event(peer, NormalSent, 0)
 }
 
+func (daita *MaybenotDaita) TunnelSent(peer *Peer) {
+	daita.event(peer, TunnelSent, 0)
+}
+
+func (daita *MaybenotDaita) TunnelReceived(peer *Peer) {
+	daita.event(peer, TunnelReceived, 0)
+}
+
 func (daita *MaybenotDaita) timerBegin(peer *Peer, machine uint64) {
 	daita.event(peer, TimerBegin, machine)
 }

--- a/device/daita_types.go
+++ b/device/daita_types.go
@@ -34,6 +34,8 @@ type Daita interface {
 	NormalReceived(peer *Peer)
 	PaddingSent(peer *Peer, machine_id uint64)
 	PaddingReceived(peer *Peer)
+	TunnelSent(peer *Peer)
+	TunnelReceived(peer *Peer)
 }
 
 func (event EventType) String() string {

--- a/device/peer.go
+++ b/device/peer.go
@@ -56,6 +56,8 @@ type Peer struct {
 
 	daita              Daita
 	constantPacketSize bool
+	outboundPackets    atomic.Int32
+	replacedPackets    atomic.Int32
 }
 
 func (device *Device) NewPeer(pk NoisePublicKey) (*Peer, error) {
@@ -220,6 +222,7 @@ func (peer *Peer) ZeroAndFlushAll() {
 	handshake.mutex.Unlock()
 
 	peer.FlushStagedPackets()
+	peer.resetOutboundAndReplaced()
 }
 
 func (peer *Peer) ExpireCurrentKeypairs() {
@@ -275,4 +278,47 @@ func (peer *Peer) SetEndpointFromPacket(endpoint conn.Endpoint) {
 	peer.Lock()
 	peer.endpoint = endpoint
 	peer.Unlock()
+}
+
+func (peer *Peer) OutboundPacketsInc() {
+	peer.outboundPackets.Add(1)
+}
+
+func (peer *Peer) OutboundPacketsDec() {
+	if peer.outboundPackets.Add(-1) < 0 {
+		panic("queuedPackets underflow")
+	}
+}
+
+func (peer *Peer) ReplacedPacketsInc() {
+	peer.replacedPackets.Add(1)
+}
+
+func (peer *Peer) OutboundAndReplacedPacketsMaybeDec(elem *QueueOutboundElement) {
+	if elem.daitaPadding {
+		return
+	}
+
+	// Saturating sub
+	for {
+		current_val := peer.replacedPackets.Load()
+		if current_val <= 0 {
+			break
+		}
+		if peer.replacedPackets.CompareAndSwap(current_val, current_val-1) {
+			break
+		}
+	}
+	if peer.outboundPackets.Add(-1) < 0 {
+		panic("queuedPackets underflow")
+	}
+}
+
+func (peer *Peer) resetOutboundAndReplaced() {
+	peer.outboundPackets.Store(0)
+	peer.replacedPackets.Store(0)
+}
+
+func (peer *Peer) HasReplaceablePackets() bool {
+	return peer.outboundPackets.Load() > peer.replacedPackets.Load()
 }

--- a/device/receive.go
+++ b/device/receive.go
@@ -163,6 +163,10 @@ func (device *Device) RoutineReceiveIncoming(recv conn.ReceiveFunc) {
 
 			// add to decryption queues
 			if peer.isRunning.Load() {
+				if peer.daita != nil {
+					peer.daita.TunnelReceived(peer)
+				}
+
 				peer.queue.inbound.c <- elem
 				device.queue.decryption.c <- elem
 				buffer = device.GetMessageBuffer()

--- a/device/send.go
+++ b/device/send.go
@@ -45,12 +45,13 @@ import (
 
 type QueueOutboundElement struct {
 	sync.Mutex
-	buffer    *[MaxMessageSize]byte // slice holding the packet data
-	packet    []byte                // slice of "buffer" (always!)
-	nonce     uint64                // nonce for encryption
-	keypair   *Keypair              // keypair for encryption
-	peer      *Peer                 // related peer
-	keepalive bool                  // is a keepalive message
+	buffer       *[MaxMessageSize]byte // slice holding the packet data
+	packet       []byte                // slice of "buffer" (always!)
+	nonce        uint64                // nonce for encryption
+	keypair      *Keypair              // keypair for encryption
+	peer         *Peer                 // related peer
+	keepalive    bool                  // is a keepalive message
+	daitaPadding bool
 }
 
 func (device *Device) NewOutboundElement() *QueueOutboundElement {
@@ -59,6 +60,7 @@ func (device *Device) NewOutboundElement() *QueueOutboundElement {
 	elem.Mutex = sync.Mutex{}
 	elem.nonce = 0
 	elem.keepalive = false
+	elem.daitaPadding = false
 	// keypair and peer were cleared (if necessary) by clearPointers.
 	return elem
 }
@@ -80,10 +82,12 @@ func (peer *Peer) SendKeepalive() {
 	if len(peer.queue.staged) == 0 && peer.isRunning.Load() {
 		elem := peer.device.NewOutboundElement()
 		elem.keepalive = true
+		peer.OutboundPacketsInc()
 		select {
 		case peer.queue.staged <- elem:
 			peer.device.log.Verbosef("%v - Sending keepalive packet", peer)
 		default:
+			peer.OutboundPacketsDec()
 			peer.device.PutMessageBuffer(elem.buffer)
 			peer.device.PutOutboundElement(elem)
 		}
@@ -272,6 +276,7 @@ func (device *Device) RoutineReadFromTUN() {
 			continue
 		}
 		if peer.isRunning.Load() {
+			peer.OutboundPacketsInc()
 			peer.StagePacket(elem)
 			elem = nil
 			peer.SendStagedPackets()
@@ -292,6 +297,7 @@ func (peer *Peer) StagePacket(elem *QueueOutboundElement) {
 		}
 		select {
 		case tooOld := <-peer.queue.staged:
+			peer.OutboundAndReplacedPacketsMaybeDec(tooOld)
 			peer.device.PutMessageBuffer(tooOld.buffer)
 			peer.device.PutOutboundElement(tooOld)
 		default:
@@ -348,6 +354,7 @@ top:
 				peer.queue.outbound.c <- elem
 				peer.device.queue.encryption.c <- elem
 			} else {
+				peer.OutboundAndReplacedPacketsMaybeDec(elem)
 				peer.device.PutMessageBuffer(elem.buffer)
 				peer.device.PutOutboundElement(elem)
 			}
@@ -361,6 +368,7 @@ func (peer *Peer) FlushStagedPackets() {
 	for {
 		select {
 		case elem := <-peer.queue.staged:
+			peer.OutboundAndReplacedPacketsMaybeDec(elem)
 			peer.device.PutMessageBuffer(elem.buffer)
 			peer.device.PutOutboundElement(elem)
 		default:
@@ -442,8 +450,10 @@ func (peer *Peer) RoutineSequentialSender() {
 		if elem == nil {
 			return
 		}
+
 		elem.Lock()
 		if !peer.isRunning.Load() {
+			peer.OutboundAndReplacedPacketsMaybeDec(elem)
 			// peer has been stopped; return re-usable elems to the shared pool.
 			// This is an optimization only. It is possible for the peer to be stopped
 			// immediately after this check, in which case, elem will get processed.
@@ -461,6 +471,7 @@ func (peer *Peer) RoutineSequentialSender() {
 		// send message and return buffer to pool
 
 		err := peer.SendBuffer(elem.packet)
+		peer.OutboundAndReplacedPacketsMaybeDec(elem)
 		if !elem.keepalive {
 			peer.timersDataSent()
 		}

--- a/device/send.go
+++ b/device/send.go
@@ -472,6 +472,10 @@ func (peer *Peer) RoutineSequentialSender() {
 			continue
 		}
 
+		if peer.daita != nil {
+			peer.daita.TunnelSent(peer)
+		}
+
 		peer.keepKeyFreshSending()
 	}
 }


### PR DESCRIPTION
Main changes:
* Add per-machine timers.
* Make padding and blocking fractions configurable (i.e. https://docs.rs/maybenot/2.0.1/maybenot/struct.Machine.html#structfield.allowed_padding_packets).
* Handle tunnel recv and send events.
* Implement `replace` flag for padding packets.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-go/18)
<!-- Reviewable:end -->
