### PR TITLE
Drop virtual network packets when overflowing

### DIFF
--- a/tun/netstack/tun.go
+++ b/tun/netstack/tun.go
@@ -60,7 +60,7 @@ func CreateNetTUN(localAddresses, dnsServers []netip.Addr, mtu int) (tun.Device,
 		ep:             channel.New(1024, uint32(mtu), ""),
 		stack:          stack.New(opts),
 		events:         make(chan tun.Event, 10),
-		incomingPacket: make(chan *buffer.View),
+		incomingPacket: make(chan *buffer.View, 1000),
 		dnsServers:     dnsServers,
 		mtu:            mtu,
 	}
@@ -148,7 +148,10 @@ func (tun *netTun) WriteNotify() {
 	view := pkt.ToView()
 	pkt.DecRef()
 
-	tun.incomingPacket <- view
+	select {
+		case tun.incomingPacket <- view:
+		default:
+	}
 }
 
 func (tun *netTun) Flush() error {


### PR DESCRIPTION
When netstack issues any kind of a write to a network, it acquires a lock. The lock is held until a write finishes. While the lock is held, calls to `Close` will block. When a wireguard device is being shut down, it stops reading from the underlying tunnel device, and tries to call `Close` on it. This can create a deadlock. To relieve this, I have changes the netstack `Tun` implementation to drop packets when they cannot be received, and introduced slight buffering - will buffer 1000 packets before dropping them. Whilst dropping packets is not great, it is better than blocking or buffering further. Since these packets operate at layer 3, it is also not unreasonable to drop them since it is appropriate for the spec. Further, this code will be used exclusively on iOS for sending ICMP traffic to the relay and negotiating ephemeral peers - so no real user traffic will end up being dropped.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-go/19)
<!-- Reviewable:end -->
