### PR TITLE
Fix formatting

### DIFF
--- a/tun/netstack/tun.go
+++ b/tun/netstack/tun.go
@@ -149,8 +149,8 @@ func (tun *netTun) WriteNotify() {
 	pkt.DecRef()
 
 	select {
-		case tun.incomingPacket <- view:
-		default:
+	case tun.incomingPacket <- view:
+	default:
 	}
 }
 


### PR DESCRIPTION
The changes I introduced to let the netstack tunnel not block writes were not formatted formatted correctly. This is more painful than it sounds - lack of formatting will fail a test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-go/21)
<!-- Reviewable:end -->
