### PR TITLE
Remove outdated .gitmodules file (maybenot no longer a submodule)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "maybenot"]
-	path = maybenot
-	url = https://github.com/mullvad/maybenot


### PR DESCRIPTION
I thought this was automatically removed when we removed the submodules via the git commands. But apparently not :shrug: This should not be here any longer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-go/24)
<!-- Reviewable:end -->
