### PR TITLE
Update changelog and add header for Mullvad release 0.1.6

### DIFF
--- a/MULLVAD-CHANGELOG.md
+++ b/MULLVAD-CHANGELOG.md
@@ -20,8 +20,15 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 ## [Unreleased]
+
+
+## [0.1.6] - 2025-02-19
 ### Changed
 - Change how maybenot-ffi is included and built as a dependency to wireguard-go with DAITA support.
+
+### Fixed
+- Synchronize shutdown of netstack write channel. Prevents panic in netstack when shutting down
+  a tunnel device.
 
 
 ## [0.1.5] - 2024-12-12


### PR DESCRIPTION
We have already bumped the main repository to point to commit 0b750ea8445a378b6f314fa6135c889e9d171b19. But there is no tag pointing to this commit or any subsequent commit. This means that when we later rebase the `mullvad` branch, these commits will be lost since nothing points to them. And since we now use these commits we need to retain them forever.

I want to add a `0.0.20230223-mullvad-0.1.6` tag, like we have done before for earlier "releases". This PR prepares for that. My plan is that once this is approved and merged to the `mullvad` branch, I will push the signed tag, preserving the much needed commits even if we later rebase `origin/mullvad`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/wireguard-go/25)
<!-- Reviewable:end -->
